### PR TITLE
ejabberdctl: improve user handling

### DIFF
--- a/ejabberdctl.template
+++ b/ejabberdctl.template
@@ -16,12 +16,13 @@ EPMD="{{epmd}}"
 INSTALLUSER={{installuser}}
 
 # check the proper system user is used if defined
-EXEC_CMD="false"
 if [ -n "$INSTALLUSER" ] ; then
-    if [ $(id -g) -eq $(id -g $INSTALLUSER || echo -1) ] ; then
+    if [ $(id -g) -eq $(id -g "$INSTALLUSER" || echo -1) ] ; then
         EXEC_CMD="as_current_user"
+    elif [ $(id -u) -eq 0 ]; then
+        EXEC_CMD="as_install_user"
     else
-        id -un | grep -q root && EXEC_CMD="as_install_user"
+        EXEC_CMD="false"
     fi
 else
     EXEC_CMD="as_current_user"


### PR DESCRIPTION
* use the numeric user ID instead of the name `root` when checking for the privileged user
    * the name `root` is not magic (it is just a convention) - only the UID zero is relevant
* do not allow partial comparisons to succeed (previously the username `xrootx` would have matched, too)
* simplify the logic flow of the conditional branches
    * this gets rid of the `[ ... ] && foo` expression, which changes the exit code of the whole `if` expression (not important right now, but this could cause subtile problems with "exit on error" (`set -e`) later on)
* add quoting for `INSTALLUSER`